### PR TITLE
Add css file to package.json exports - fix for webpack5 projects

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,7 +20,8 @@
   "module": "./lib/esm/index.js",
   "typings": "./lib/esm/",
   "exports": {
-    ".": "./lib/esm/index.js"
+    ".": "./lib/esm/index.js",
+    "./lib/react-sigma-v2.css": "./lib/react-sigma-v2.css"
   },
   "directories": {
     "example": "examples"


### PR DESCRIPTION
Getting the error `Module not found: Error: Package path ./lib/react-sigma-v2.css is not exported from package` when using webpack 5

Latest version of webpack is strictly enforcing the `exports` field in package.json. The css file must be specified also. More info: https://github.com/webpack/webpack/issues/9509

Thanks for this awesome package :)



